### PR TITLE
[Feature] Update Node.js version from v16 to v20, as that is the new LTS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
       - run: npm ci
       - run: npm run build
       - run: npm run format-check

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A GitHub action to create a repository dispatch event.
 
+### Requirements:
+
+* NodeJS 20+
+
 ## Usage
 
 Dispatch an event to the current repository.

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: 'JSON payload with extra information about the webhook event that your action or worklow may use.'
     default: '{}'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'target'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "repository-dispatch",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "repository-dispatch",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/jest": "^27.0.3",
-        "@types/node": "^18.16.19",
+        "@types/node": "^20.8.7",
         "@typescript-eslint/parser": "^5.61.0",
         "@vercel/ncc": "^0.36.1",
         "eslint": "^8.44.0",
@@ -1807,10 +1807,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
-      "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
-      "dev": true
+      "version": "20.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
+      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.4.2",
@@ -7667,6 +7670,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "dev": true
+    },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
@@ -9442,10 +9451,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.16.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
-      "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
-      "dev": true
+      "version": "20.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
+      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.25.1"
+      }
     },
     "@types/prettier": {
       "version": "2.4.2",
@@ -13806,6 +13818,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "dev": true
     },
     "universal-user-agent": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repository-dispatch",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "private": true,
   "description": "Create a repository dispatch event",
   "main": "lib/main.js",
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",
-    "@types/node": "^18.16.19",
+    "@types/node": "^20.8.7",
     "@typescript-eslint/parser": "^5.61.0",
     "@vercel/ncc": "^0.36.1",
     "eslint": "^8.44.0",


### PR DESCRIPTION
Related to Issue [#9895](https://github.com/Submitty/Submitty/issues/9895)

The following changes have been made since Node.js v20 is the new LTS version. You can find more information in the linked issue.

1. Updated `action.yml` so that it uses Node.js version `'node20'`
2. Updated `ci.yml` so that it uses Node.js version `20.x` 
3. Updated version to `3.0.0` in `package.json` to reflect this change, as this is a breaking change, according to the rules of [semantic versioning](https://docs.npmjs.com/about-semantic-versioning)
4. Upgraded `@types/node` version to `"^20.8.7"` to match Node.js v20 version
5. Updated `README.md` to reflect these changes

P.S. If this PR is accepted, could you please add the "hacktoberfest-accepted" label to it, so that it counts towards my Hacktoberfest contributions?